### PR TITLE
Add column

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GORM MySQL Driver
+# GORM ClickHouse Driver
 
 ## Quick Start
 

--- a/migrator.go
+++ b/migrator.go
@@ -150,6 +150,32 @@ func (m Migrator) HasTable(value interface{}) bool {
 
 // Columns
 
+func (m Migrator) AddColumn(value interface{}, field string) error {
+	return m.RunWithValue(value, func(stmt *gorm.Statement) error {
+		if field := stmt.Schema.LookUpField(field); field != nil {
+			return m.DB.Exec(
+				"ALTER TABLE ? ADD COLUMN ? ?",
+				clause.Table{Name: stmt.Table}, clause.Column{Name: field.DBName},
+				m.FullDataTypeOf(field),
+			).Error
+		}
+		return fmt.Errorf("failed to look up field with name: %s", field)
+	})
+}
+
+func (m Migrator) DropColumn(value interface{}, name string) error {
+	return m.RunWithValue(value, func(stmt *gorm.Statement) error {
+		if field := stmt.Schema.LookUpField(name); field != nil {
+			name = field.DBName
+		}
+		fmt.Println("ALTER TABLE ? DROP COLUMN")
+		return m.DB.Exec(
+			"ALTER TABLE ? DROP COLUMN ?",
+			clause.Table{Name: stmt.Table}, clause.Column{Name: name},
+		).Error
+	})
+}
+
 func (m Migrator) AlterColumn(value interface{}, field string) error {
 	return m.RunWithValue(value, func(stmt *gorm.Statement) error {
 		if field := stmt.Schema.LookUpField(field); field != nil {


### PR DESCRIPTION
## Description

Fixed syntax for `ALTER TABLE ? ADD COLUMN ?` by defining a function:

```
func(m Migrator) AddColumn(value interface{}, name string) error
```

## Feature Coverage in `ADD COLUMN`

According to the official [ClickHouse docs](https://clickhouse.tech/docs/en/sql-reference/statements/alter/column/):
```
ADD COLUMN [IF NOT EXISTS] name [type] [default_expr] [codec] [AFTER name_after]
```
- The statement sure require **name** and **type** of column
- The statement clause supports adding **Default expr** and **codec** immediately in the `ADD COLUMN`
- The statement also supports the ordering of column using `AFTER name_after`, so that the order which of scanning fields is predictable and consistent. Otherwise new column will always put as the last column to scan.
- The statement doesn't support adding **TTL Expr**

### Feature done in `ADD COLUMN`

- [x] Ensure correctness for `name` and `TYPE` of column

- [ ] Support specifying `DEFAULT expr` and `Codec` from golang tag `gorm:"[column_options]..."`

- [ ] Enable auto ordering using name `AFTER name_after`. 

## Tests:

Manual testing. 